### PR TITLE
Fix CI memory error at npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,16 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --no-audit --no-fund
+        env:
+          NODE_OPTIONS: '--max-old-space-size=2048'
 
       - run: echo '{}' > .local-config.json
 
       - name: Build
         run: npm run build
+        env:
+          NODE_OPTIONS: '--max-old-space-size=2048'
 
       - name: Run E2E tests
         run: npx start-server-and-test 'npm start' http://localhost:3000 'npx cypress run'


### PR DESCRIPTION
## Summary
- allow npm to complete in low-memory environments by limiting Node's heap
- disable progress/no-op audit to speed up installation

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb91d0348324b23f9d9e5cca4222