### PR TITLE
Fix CI by serving static build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Install Xvfb for Cypress
-        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Install Cypress dependencies
+        run: sudo apt-get update && sudo apt-get install -y \
+          xvfb libnss3 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2
 
       - name: Run E2E tests
         run: npx start-server-and-test 'npm start' http://localhost:3000 'npx cypress run'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
         run: npm run build
 
       - name: Install Cypress dependencies
-        run: sudo apt-get update && sudo apt-get install -y \
-          xvfb libnss3 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb libnss3 libatk-bridge2.0-0 libgtk-3-0 libxss1 libasound2
 
       - name: Run E2E tests
         run: npx start-server-and-test 'npm start' http://localhost:3000 'npx cypress run'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Install Xvfb for Cypress
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Run E2E tests
         run: npx start-server-and-test 'npm start' http://localhost:3000 'npx cypress run'
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev -p 3000",
     "turbo": "next dev -p 3000 --turbo",
     "build": "next build",
-    "start": "next start",
+    "start": "npx --yes serve@latest out -l 3000",
     "lint": "next lint",
     "cypress:open": "cypress open"
   },


### PR DESCRIPTION
## Summary
- serve the exported app with `serve` in the `start` script
- run cypress tests using the new start script

## Testing
- `npm run lint`
- `npx --yes start-server-and-test 'npm start' http://localhost:3000 'npx cypress run'` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6842c68e61048324a3f0fc0daa9d3e54