### PR TITLE
Fix Cypress test for install tabs

### DIFF
--- a/cypress/e2e/test.cy.ts
+++ b/cypress/e2e/test.cy.ts
@@ -2,12 +2,12 @@ describe("Click all tabs in peer modal", () => {
   it("passes", () => {
     cy.visit("/install");
     cy.get("div").contains("Linux").click();
-    cy.get("[data-cy=copy-to-clipboard]").click();
+    cy.get("[data-cy=copy-to-clipboard]").first().click();
     cy.get("div").contains("Windows").click();
-    cy.get("[data-cy=copy-to-clipboard]").click();
+    cy.get("[data-cy=copy-to-clipboard]").first().click();
     cy.get("div").contains("Android").click();
-    cy.get("[data-cy=copy-to-clipboard]").click();
+    cy.get("[data-cy=copy-to-clipboard]").first().click();
     cy.get("div").contains("Docker").click();
-    cy.get("[data-cy=copy-to-clipboard]").click();
+    cy.get("[data-cy=copy-to-clipboard]").first().click();
   });
 });


### PR DESCRIPTION
## Summary
- update e2e test to click only one copy button per step

## Testing
- `npx cypress run --component false --spec cypress/e2e/test.cy.ts` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842e39a3e6c8324adf9a628aca4b823