### PR TITLE
Fix Docker build by generating static 'out' folder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,11 @@
-FROM alpine:3.14
+FROM node:18 AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
 
+FROM alpine:3.14
 RUN apk add --no-cache bash curl less ca-certificates git tzdata zip gettext \
     nginx curl supervisor certbot-nginx && \
     rm -rf /var/cache/apk/* && mkdir -p /run/nginx
@@ -21,4 +27,4 @@ RUN chmod +x /usr/local/init_react_envs.sh
 # configure supervisor
 COPY docker/supervisord.conf /etc/supervisord.conf
 # copy build files
-COPY out/ /usr/share/nginx/html/
+COPY --from=build /app/out/ /usr/share/nginx/html/


### PR DESCRIPTION
## Summary
- build the Next.js static site within Docker using a Node build stage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842e2e0f2908324bd54b30223fcc9a2